### PR TITLE
fix: estimate ghost replay time from frame count for legacy/stale rep…

### DIFF
--- a/src/services/demo-service.test.ts
+++ b/src/services/demo-service.test.ts
@@ -53,6 +53,8 @@ describe('DemoService replay format', () => {
     expect(replay?.frames[0].position).toEqual({ x: 10, y: 11, z: 12 });
     expect(replay?.metadata.mapName).toBe('level1');
     expect(replay?.metadata.source).toBe('migrated-legacy');
+    expect(replay?.metadata.timeMs).toBeGreaterThan(0);
+    expect(replay?.metadata.timeStr).not.toBe('00:00.000');
     expect(type).toBe('local-best');
   });
 
@@ -101,8 +103,27 @@ describe('DemoService replay format', () => {
     expect(replay).toBeTruthy();
     expect(replay?.version).toBe(REPLAY_FORMAT_VERSION);
     expect(replay?.metadata.source).toBe('bundled');
+    expect(replay?.metadata.timeMs).toBeGreaterThan(0);
+    expect(replay?.metadata.timeStr).not.toBe('00:00.000');
     expect(fetch).toHaveBeenCalledWith('assets/demo/map-record.json');
     expect(localStorage.getItem('replay_bundled_record_level1')).toContain('"version":1');
+  });
+
+  it('estimates time from frame count for legacy replay', () => {
+    const service = new DemoService();
+    const frameCount = 600; // 10 seconds at 60fps
+    const frames = Array.from({ length: frameCount }, (_, i) => ({
+      position: { _x: i, _y: 0, _z: 0 },
+      rotation: { _x: 0, _y: 0, _z: 0, _w: 1 },
+    }));
+    localStorage.setItem('demo', JSON.stringify(frames));
+
+    const { replay } = service.loadStoredReplay('level1');
+
+    expect(replay).toBeTruthy();
+    // 600 frames * (1000/60) ms per frame = 10000ms = 10 seconds
+    expect(replay?.metadata.timeMs).toBe(10000);
+    expect(replay?.metadata.timeStr).toBe('00:10.000');
   });
 
   it('warns when migrating legacy stored replay', () => {
@@ -124,5 +145,70 @@ describe('DemoService replay format', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[Replay] Migrated legacy generic replay data to local-best v1 format.'
     );
+  });
+
+  it('re-estimates time for v1 replay with timeMs=0 (stale localStorage)', () => {
+    const service = new DemoService();
+    // Simulate a v1 replay stored with timeMs: 0 (as produced by the old defaultMetadata)
+    const frames = Array.from({ length: 120 }, (_, i) => ({
+      position: { x: i, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+    }));
+    const staleReplay = {
+      version: REPLAY_FORMAT_VERSION,
+      frames,
+      metadata: {
+        playerName: 'Map record',
+        timeMs: 0,
+        timeStr: '00:00.000',
+        completedAt: '2026-01-01T00:00:00.000Z',
+        mapName: 'level1',
+        replayVersion: 1,
+        source: 'bundled',
+      },
+    };
+    localStorage.setItem('replay_bundled_record_level1', JSON.stringify(staleReplay));
+
+    const { replay, type } = service.loadStoredReplay('level1');
+
+    expect(replay).toBeTruthy();
+    expect(replay?.metadata.timeMs).toBeGreaterThan(0);
+    expect(replay?.metadata.timeStr).not.toBe('00:00.000');
+    expect(replay?.metadata.source).toBe('bundled');
+    expect(type).toBe('bundled-record');
+
+    // The stale data should have been migrated (saved back with corrected time)
+    const stored = JSON.parse(localStorage.getItem('replay_bundled_record_level1')!);
+    expect(stored.metadata.timeMs).toBeGreaterThan(0);
+    expect(stored.metadata.timeStr).not.toBe('00:00.000');
+  });
+
+  it('preserves valid timeMs from existing v1 replay', () => {
+    const service = new DemoService();
+    const frames = Array.from({ length: 10 }, (_, i) => ({
+      position: { x: i, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0, w: 1 },
+    }));
+    const goodReplay = {
+      version: REPLAY_FORMAT_VERSION,
+      frames,
+      metadata: {
+        playerName: 'Player1',
+        timeMs: 5000,
+        timeStr: '00:05.000',
+        completedAt: '2026-01-01T00:00:00.000Z',
+        mapName: 'level1',
+        replayVersion: 1,
+        source: 'local',
+      },
+    };
+    localStorage.setItem('replay_local_best_level1', JSON.stringify(goodReplay));
+
+    const { replay, type } = service.loadStoredReplay('level1');
+
+    expect(replay).toBeTruthy();
+    expect(replay?.metadata.timeMs).toBe(5000);
+    expect(replay?.metadata.timeStr).toBe('00:05.000');
+    expect(type).toBe('local-best');
   });
 });

--- a/src/services/demo-service.ts
+++ b/src/services/demo-service.ts
@@ -79,11 +79,24 @@ export class DemoService {
   playingEntity: BABYLON.Mesh | null = null;
   scene: BABYLON.Scene | null = null;
 
-  private defaultMetadata(mapName: string, source: ReplayMetadata['source']): ReplayMetadata {
+  private formatTimeMs(ms: number): string {
+    const date = new Date(ms);
+    const minutes = date.getUTCMinutes().toString().padStart(2, '0');
+    const seconds = date.getUTCSeconds().toString().padStart(2, '0');
+    const milliseconds = date.getUTCMilliseconds().toString().padStart(3, '0');
+    return `${minutes}:${seconds}.${milliseconds}`;
+  }
+
+  private defaultMetadata(
+    mapName: string,
+    source: ReplayMetadata['source'],
+    estimatedTimeMs?: number
+  ): ReplayMetadata {
+    const timeMs = estimatedTimeMs ?? 0;
     return {
       playerName: 'Map record',
-      timeMs: 0,
-      timeStr: '00:00.000',
+      timeMs,
+      timeStr: timeMs > 0 ? this.formatTimeMs(timeMs) : '00:00.000',
       completedAt: new Date().toISOString(),
       mapName,
       replayVersion: REPLAY_FORMAT_VERSION,
@@ -153,16 +166,22 @@ export class DemoService {
   private normalizeMetadata(
     metadata: unknown,
     mapName: string,
-    defaultSource: ReplayMetadata['source']
+    defaultSource: ReplayMetadata['source'],
+    frameCount = 0
   ): ReplayMetadata {
-    const defaults = this.defaultMetadata(mapName, defaultSource);
+    const estimatedTimeMs = frameCount > 0 ? frameCount * SAMPLE_RATE_MS : undefined;
+    const defaults = this.defaultMetadata(mapName, defaultSource, estimatedTimeMs);
 
     const playerName = readString(metadata, 'playerName') ?? defaults.playerName;
-    const timeStr = readString(metadata, 'timeStr') ?? defaults.timeStr;
     const mapNameValue = readString(metadata, 'mapName') ?? defaults.mapName;
 
     const timeMsValue = readNumber(metadata, 'timeMs');
-    const timeMs = timeMsValue === null || timeMsValue < 0 ? defaults.timeMs : timeMsValue;
+    // Treat timeMs <= 0 as missing — legacy replays had no timer data
+    const timeMs = timeMsValue !== null && timeMsValue > 0 ? timeMsValue : defaults.timeMs;
+
+    const timeStrValue = readString(metadata, 'timeStr');
+    const timeStr =
+      timeStrValue && timeMsValue !== null && timeMsValue > 0 ? timeStrValue : defaults.timeStr;
 
     const completedAt = readString(metadata, 'completedAt') ?? defaults.completedAt;
     const completedAtDate = new Date(completedAt);
@@ -198,12 +217,13 @@ export class DemoService {
         .filter((frame): frame is ReplayFrameData => frame !== null);
       if (frames.length === 0) return { replay: null, migrated: false };
 
+      const estimatedTimeMs = frames.length * SAMPLE_RATE_MS;
       const source = defaultSource === 'local' ? 'migrated-legacy' : defaultSource;
       return {
         replay: {
           version: REPLAY_FORMAT_VERSION,
           frames,
-          metadata: this.defaultMetadata(mapName, source),
+          metadata: this.defaultMetadata(mapName, source, estimatedTimeMs),
         },
         migrated: true,
       };
@@ -219,8 +239,17 @@ export class DemoService {
 
     if (frames.length === 0) return { replay: null, migrated: false };
 
-    const metadata = this.normalizeMetadata(payload.metadata, mapName, defaultSource);
-    const migrated = !isRecord(payload.metadata) || typeof payload.metadata.source !== 'string';
+    const rawTimeMs = isRecord(payload.metadata) ? readNumber(payload.metadata, 'timeMs') : null;
+    const metadata = this.normalizeMetadata(
+      payload.metadata,
+      mapName,
+      defaultSource,
+      frames.length
+    );
+    const migrated =
+      !isRecord(payload.metadata) ||
+      typeof payload.metadata.source !== 'string' ||
+      (rawTimeMs !== null && rawTimeMs <= 0);
 
     return {
       replay: {


### PR DESCRIPTION
…lays

Legacy replay formats (bare arrays) and v1 payloads with timeMs=0 previously showed 'Time: 00:00.000' on the scoreboard because defaultMetadata() hardcoded timeMs: 0 and normalizeMetadata() treated timeMs: 0 as valid.

Changes:
- Add formatTimeMs() to compute 'MM:SS.mmm' from milliseconds
- defaultMetadata() now accepts optional estimatedTimeMs parameter
- normalizeMetadata() receives frame count and estimates time when timeMs is 0 or missing
- normalizeReplayPayload() estimates time for legacy arrays AND v1 payloads with timeMs <= 0
- v1 payloads with timeMs <= 0 are marked as migrated (re-saved)
- This auto-heals stale localStorage data from before this fix