### PR TITLE
feat: compact ghost replay metadata display

### DIFF
--- a/public/assets/ui/time-table/time-table.css
+++ b/public/assets/ui/time-table/time-table.css
@@ -12,9 +12,19 @@
 }
 
 .time-table > .replay-metadata {
-  color: var(--color-text-secondary);
+  color: var(--color-text-primary);
   font-size: var(--font-size-ui-sm);
   margin-top: var(--space-sm);
+}
+
+.replay-metadata__primary {
+  display: block;
+}
+
+.replay-metadata__secondary {
+  color: var(--color-text-secondary);
+  display: block;
+  font-size: var(--font-size-ui-xs);
 }
 
 @media only screen and (max-width: 1000px) {

--- a/src/ui/time-table/time-table-ui.test.ts
+++ b/src/ui/time-table/time-table-ui.test.ts
@@ -95,11 +95,30 @@ describe('TimeTableUI', () => {
       source: 'local',
     });
 
-    expect(ui.replayMetadataDiv.innerText).toContain('Ghost: runner');
-    expect(ui.replayMetadataDiv.innerText).toContain('Time: 00:45.234');
-    expect(ui.replayMetadataDiv.innerText).toContain('Map: level1');
-    expect(ui.replayMetadataDiv.innerText).toContain('Source: Local record');
-    expect(ui.replayMetadataDiv.innerText).toContain('Replay v1');
     expect(ui.replayMetadataDiv.style.display).toBe('block');
+    const primary = ui.replayMetadataDiv.querySelector('.replay-metadata__primary');
+    const secondary = ui.replayMetadataDiv.querySelector('.replay-metadata__secondary');
+    expect(primary?.textContent).toBe('Map: level1');
+    expect(secondary?.textContent).toBe('Ghost: 00:45.234 - runner');
+  });
+
+  it('renders bundled replay metadata without source label or date', () => {
+    const ui = new TimeTableUI({} as never, {} as never);
+    ui.replayMetadataDiv = document.createElement('div');
+
+    ui.updateReplayMetadata({
+      playerName: 'Map record',
+      timeMs: 176717,
+      timeStr: '02:56.717',
+      completedAt: '2026-06-14T00:00:00.000Z',
+      mapName: 'level1',
+      replayVersion: 1,
+      source: 'bundled',
+    });
+
+    const primary = ui.replayMetadataDiv.querySelector('.replay-metadata__primary');
+    const secondary = ui.replayMetadataDiv.querySelector('.replay-metadata__secondary');
+    expect(primary?.textContent).toBe('Map: level1');
+    expect(secondary?.textContent).toBe('Ghost: 02:56.717 - Map record');
   });
 });

--- a/src/ui/time-table/time-table-ui.ts
+++ b/src/ui/time-table/time-table-ui.ts
@@ -37,23 +37,11 @@ export class TimeTableUI extends AbstractUI {
   updateReplayMetadata(metadata: ReplayMetadata): void {
     if (!this.replayMetadataDiv) return;
 
-    const sourceLabel =
-      metadata.source === 'local'
-        ? 'Local record'
-        : metadata.source === 'bundled'
-          ? 'Bundled map record'
-          : 'Migrated legacy record';
+    this.replayMetadataDiv.innerHTML = [
+      `<span class="replay-metadata__primary">Map: ${metadata.mapName}</span>`,
+      `<span class="replay-metadata__secondary">Ghost: ${metadata.timeStr} - ${metadata.playerName}</span>`,
+    ].join('');
 
-    const details = [
-      `Ghost: ${metadata.playerName}`,
-      `Time: ${metadata.timeStr}`,
-      `Map: ${metadata.mapName}`,
-      `Date: ${new Date(metadata.completedAt).toLocaleDateString()}`,
-      `Source: ${sourceLabel}`,
-      `Replay v${metadata.replayVersion}`,
-    ].join(' | ');
-
-    this.replayMetadataDiv.innerText = details;
     this.replayMetadataDiv.style.display = 'block';
   }
 


### PR DESCRIPTION
Reformat the scoreboard ghost info into a compact two-line layout:

  Map: level1
  Ghost: 02:56.716 - Map record

- Line 1: map name
- Line 2: 'Ghost:' label, time, and player name
- Source label and date removed entirely
- Replay version dropped (not useful to players)